### PR TITLE
Add reverse proxy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -285,3 +285,6 @@ $RECYCLE.BIN/
 
 .vscode
 staticfiles
+
+# JetBrains WebStorm
+.idea/

--- a/app/frontend/public/index.html
+++ b/app/frontend/public/index.html
@@ -6,12 +6,12 @@
 
 	<title>UpSnap</title>
 
-	<link rel='icon' type='image/png' href='/favicon.png'>
-	<link rel='stylesheet' href='/global.css'>
-	<link rel='stylesheet' href='/build/bundle.css'>
+	<link rel='icon' type='image/png' href='favicon.png'>
+	<link rel='stylesheet' href='global.css'>
+	<link rel='stylesheet' href='build/bundle.css'>
 
-	<script defer src='/build/bundle.js'></script>
-	<script defer src='/build/bootstrap.min.js'></script>
+	<script defer src='build/bundle.js'></script>
+	<script defer src='build/bootstrap.min.js'></script>
 </head>
 
 <body>

--- a/app/frontend/rollup.config.js
+++ b/app/frontend/rollup.config.js
@@ -52,6 +52,7 @@ export default {
 		}),
 		replace({
 			BACKEND_PORT: JSON.stringify(process.env.BACKEND_PORT),
+			BACKEND_IS_PROXIED: JSON.stringify(!!process.env.BACKEND_IS_PROXIED),
 			preventAssignment: true
 		}),
 		// we'll extract any component CSS out into

--- a/app/frontend/src/components/Navbar.svelte
+++ b/app/frontend/src/components/Navbar.svelte
@@ -92,7 +92,7 @@
 <nav class="navbar navbar-expand-sm">
     <div class="container-fluid">
         <div class="navbar-brand" href="/">
-            <img src="/favicon.png" alt="Logo" width="24" height="24" class="me-2">
+            <img src="favicon.png" alt="Logo" width="24" height="24" class="me-2">
             UpSnap
         </div>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">

--- a/app/frontend/src/socketStore.js
+++ b/app/frontend/src/socketStore.js
@@ -7,7 +7,15 @@ const message = writable('');
 let socket;
 
 function initSocket() {
-    socket = new WebSocket(`ws://${location.hostname}:${BACKEND_PORT}/wol/`);
+    if (BACKEND_IS_PROXIED) {
+        const socketUrl = new URL('/wol/', window.location.href);
+        socketUrl.protocol = socketUrl.protocol.replace('http', 'ws');
+
+        socket = new WebSocket(socketUrl);
+    }
+    else {
+        socket = new WebSocket(`ws://${location.hostname}:${BACKEND_PORT}/wol/`);
+    }
 
     // Connection opened
     socket.addEventListener('open', function () {

--- a/app/frontend/src/socketStore.js
+++ b/app/frontend/src/socketStore.js
@@ -8,7 +8,7 @@ let socket;
 
 function initSocket() {
     if (BACKEND_IS_PROXIED) {
-        const socketUrl = new URL('/wol/', window.location.href);
+        const socketUrl = new URL('wol/', window.location.href);
         socketUrl.protocol = socketUrl.protocol.replace('http', 'ws');
 
         socket = new WebSocket(socketUrl);


### PR DESCRIPTION
The front end and back end can now be reverse proxied together under the same hostname and port.

A new environment variable named `BACKEND_IS_PROXIED` has been added. When set to a truthy value the front end will use its own address as the base URL for connecting to the back end.

Resource paths have been made relative as well so in addition to using a subdomain (http://upsnap.example.com) for the proxy, a subfolder can also be used (http://example.com/upsnap/).

I can add reverse proxy examples as well. I just wasn't sure where you wanted them.