### PR TITLE
removed version line from docker compose yml files

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   upsnap:
     container_name: upsnap

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   upsnap:
     container_name: upsnap


### PR DESCRIPTION
Removed `version: "3"` line from docker compose yml files.
Docker compose no longer uses 'version.' Specifying version will throw a warning that version is obsolete. 