### PR TITLE
add clarity for UPSNAP_PING_PRIVILEGED setting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     #   - UPSNAP_INTERVAL=*/10 * * * * * # Sets the interval in which the devices are pinged
     #   - UPSNAP_SCAN_RANGE=192.168.1.0/24 # Scan range is used for device discovery on local network
     #   - UPSNAP_SCAN_TIMEOUT=500ms # Scan timeout is nmap's --host-timeout value to wait for devices (https://nmap.org/book/man-performance.html)
-    #   - UPSNAP_PING_PRIVILEGED=true # Set to false if you don't have root user permissions
+    #   - UPSNAP_PING_PRIVILEGED=true # Set to false if non-root user and no NET_RAW capability *requires host setting net.ipv4.ping_group_range="0   2147483647"
     #   - UPSNAP_WEBSITE_TITLE=Custom name # Custom website title
     # # dns is used for name resolution during network scan
     # dns:


### PR DESCRIPTION
Address #1574 to add clarity to the UPSNAP_PING_PRIVILEGED setting, and  `sudo sysctl -w net.ipv4.ping_group_range="0   2147483647"` being required for unprivileged pings.