### PR TITLE
fix: switch cron-parser to named import (CronExpressionParser)

### DIFF
--- a/frontend/src/lib/helpers/cron.ts
+++ b/frontend/src/lib/helpers/cron.ts
@@ -1,13 +1,13 @@
 import { m } from '$lib/paraglide/messages';
 import { dateFnsLocale } from '$lib/stores/locale';
 import { backendUrl } from '$lib/stores/pocketbase';
-import cronParser from 'cron-parser';
+import { CronExpressionParser } from 'cron-parser';
 import { formatDate, type Locale } from 'date-fns';
 import { get } from 'svelte/store';
 
 export function nextCronDate(expression: string) {
 	try {
-		const cron = cronParser.parse(expression);
+		const cron = CronExpressionParser.parse(expression);
 		const cronStr = cron.next().toISOString();
 		if (!cronStr) {
 			throw new Error(m.settings_invalid_cron());

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -10,7 +10,7 @@
 	import { settingsPriv, settingsPub } from '$lib/stores/settings';
 	import type { SettingsPrivate, SettingsPublic } from '$lib/types/settings';
 	import { faSave } from '@fortawesome/free-solid-svg-icons';
-	import cronParser from 'cron-parser';
+	import { CronExpressionParser } from 'cron-parser';
 	import { onMount } from 'svelte';
 	import Fa from 'svelte-fa';
 	import toast from 'svelte-french-toast';
@@ -61,7 +61,7 @@
 			return;
 
 		try {
-			cronParser.parse(settingsPrivClone.interval);
+			CronExpressionParser.parse(settingsPrivClone.interval);
 		} catch {
 			toast.error(m.settings_invalid_cron());
 			throw new Error(`failed to parse cron: ` + settingsPrivClone.interval);


### PR DESCRIPTION
The previous Cron Parser was not correctly parsing the cron schedules as shown in the below screenshot

<img width="354" height="74" alt="image" src="https://github.com/user-attachments/assets/82e1a7be-3efb-4b2a-93da-c4dff744893d" />

The cron.ts nextCronDate always threw a TypeError which caught and threw Invalid cron

With the fix, it's now showing the correct cron schedules

<img width="352" height="81" alt="image" src="https://github.com/user-attachments/assets/083eb5a1-b430-4746-84d1-24dc15fe9e98" />

