### PR TITLE
Add OCI standard labels to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN apk update &&\
     rm -rf /var/cache/apk/*
 WORKDIR /app
 COPY --from=downloader /app/upsnap upsnap
+LABEL org.opencontainers.image.source="https://github.com/seriousm4x/UpSnap" \
+      org.opencontainers.image.url="https://github.com/seriousm4x/UpSnap" \
+      org.opencontainers.image.licenses="MIT"
 HEALTHCHECK --interval=10s \
     CMD curl -fs "http://${UPSNAP_HTTP_LISTEN}/api/health" || exit 1
 CMD ["serve","--http","${UPSNAP_HTTP_LISTEN}"]


### PR DESCRIPTION
Howdy! Just a small thing I noticed - I use Renovate to help update my Docker containers, and it has a handy feature that looks up the changelog or release notes via the GitHub repository URL so it can be displayed inline in the PR it opens. Per [Renovate's documentation](https://docs.renovatebot.com/modules/datasource/docker/#description), the `org.opencontainers.image.source` label needs to point to the repository for them to grab release notes. Renovate cites their Dockerfile as an example, and they have a couple of extra labels in [their Dockerfile](https://github.com/renovatebot/renovate/blob/main/tools/docker/Dockerfile), so I figured I'd pop those in as well.

No particularly strong feelings on the labeling itself, styling, etc; so feel free to make any changes deemed necessary :) I think also this could go in to the actual release workflow itself if preferred.

Thanks!