### PR TITLE
fix: create user `upsnap` with UID:GID 1000:1000 for ssh/sshpass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ ENV UPSNAP_HTTP_LISTEN=${UPSNAP_HTTP_LISTEN}
 RUN apk update &&\
     apk add --no-cache tzdata ca-certificates nmap samba samba-common-tools openssh sshpass curl &&\
     rm -rf /var/cache/apk/*
+RUN addgroup -g 1000 &&\
+    adduser -G upsnap -D -H -u 1000 upsnap -s /sbin/nologin
 WORKDIR /app
 COPY --from=downloader /app/upsnap upsnap
 LABEL org.opencontainers.image.source="https://github.com/seriousm4x/UpSnap" \


### PR DESCRIPTION
Resolves #1748 

Also, a proposed update to the Wiki:
https://github.com/seriousm4x/UpSnap/wiki/Use-non%E2%80%90root-user#docker

```
2. Add `user: 1000:1000` to your `docker-compose.yml`. IMPORTANT note if you use ssh/sshpass in your wake/shutdown commands: this image creates an `upsnap` user and group in order for `ssh` and `sshpass` to work properly. If you want a different UID/GID and use ssh/sshpass, you must build a custom image.
```