### PR TITLE
Fix: subnet mask check

### DIFF
--- a/backend/networking/magicpacket.go
+++ b/backend/networking/magicpacket.go
@@ -88,8 +88,7 @@ func getBroadcastIp(ipStr, maskStr string) (string, error) {
 		return "", errors.New("subnet mask not a valid ipv4 address")
 	}
 	mask = mask.To4()
-	ip = ip.To4()
-	if ip == nil {
+	if mask == nil {
 		return "", errors.New("subnet mask not a valid ipv4 address")
 	}
 


### PR DESCRIPTION
Possibly a copy and paste error when code was originally introduced.  Removed extra line and replaced `ip` with `mask`.