### PR TITLE
fix: use working star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,4 +198,4 @@ Open up [http://localhost:5173/](http://localhost:5173/), create an admin user a
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=seriousm4x/UpSnap&type=Date&theme=dark)](https://star-history.com/#seriousm4x/UpSnap&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=seriousm4x/UpSnap&type=Date&theme=dark)](https://star-history.dera.page/#seriousm4x/UpSnap&Date)


### PR DESCRIPTION
The current star history chart is broken due to GitHub stargazer API restrictions. This updates the chart so it keeps working reliably without requiring an API token.